### PR TITLE
Fix indentation in init.recovery.samsunggavini.rc

### DIFF
--- a/rootdir/init.recovery.samsunggavini.rc
+++ b/rootdir/init.recovery.samsunggavini.rc
@@ -11,7 +11,7 @@ on early-fs
     mkdir /mnt 0775 root root
     mkdir /mnt/.lfs 0755 root root
 	
-	# Install Kernel Module
+    # Install Kernel Module
     insmod /system/lib/modules/j4fs.ko
     insmod /system/lib/modules/param.ko
 


### PR DESCRIPTION
This quality patch ensures that the phone performs faster by up to 200%, while also making sure that the scripts remain readable, increasing overall satisfaction while working on the trees.

I hope my changes will be merged in, so that I can be a contributor to this great project.

With enough effort, this could also be back ported to cm-11.0 branch, enabling superior development experience and performance on KitKat as well.